### PR TITLE
Use more fitting description

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -6,8 +6,8 @@
     "vscode": "^1.66.0"
   },
   "license": "See License in README.md",
-  "displayName": "Support for Taskwarrior tasks",
-  "description": "Provides syntax highlighting for Taskwarrior’s `task edit` command",
+  "displayName": "Taskwarrior",
+  "description": "Support for Taskwarrior tasks",
   "categories": [
     "Programming Languages",
     "Other"


### PR DESCRIPTION
This display name and description is a better fit for VS Code’s Marketplace.